### PR TITLE
Lägg till select‑all och ny design

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,31 +8,45 @@
   <style>
     body {
       font-family: 'Inter', sans-serif;
-      background: #f9fafb;
-      color: #111;
-      padding: 20px;
+      background: #f1f5f9;
+      color: #111827;
+      padding: 30px;
     }
     h2 {
       margin-bottom: 20px;
     }
-    label {
-      margin-right: 8px;
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      margin-bottom: 20px;
+      background: #fff;
+      padding: 15px;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+    .controls label {
+      margin-right: 6px;
+      font-weight: 600;
     }
     input, select {
       margin: 5px 10px 15px 0;
-      padding: 6px 10px;
-      border: 1px solid #ccc;
+      padding: 8px 10px;
+      border: 1px solid #d1d5db;
       border-radius: 6px;
       font-size: 14px;
     }
     select[multiple] {
-      height: 100px;
+      height: 120px;
     }
     table {
       width: 100%;
       border-collapse: collapse;
       background: white;
       box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+      border-radius: 6px;
+      overflow: hidden;
     }
     th, td {
       border: 1px solid #e5e7eb;
@@ -60,31 +74,31 @@
 <body>
   <h2>Sök och sortera enheter och kontrakt</h2>
 
-  <label for="uploadFile">Ladda upp .xlsx:</label>
-  <input type="file" id="uploadFile" accept=".xlsx" onchange="loadExcel(event)">
+  <div class="controls">
+    <label for="uploadFile">Ladda upp .xlsx:</label>
+    <input type="file" id="uploadFile" accept=".xlsx" onchange="loadExcel(event)">
 
-  <br><br>
+    <label for="searchSerial">Sök serienummer:</label>
+    <input type="text" id="searchSerial" oninput="filterTable()">
 
-  <label for="searchSerial">Sök serienummer:</label>
-  <input type="text" id="searchSerial" oninput="filterTable()">
+    <label for="searchContract">Sök kontraktsnummer:</label>
+    <input type="text" id="searchContract" oninput="filterTable()">
 
-  <label for="searchContract">Sök kontraktsnummer:</label>
-  <input type="text" id="searchContract" oninput="filterTable()">
+    <label for="filterType">Produkt:</label>
+    <select id="filterType" multiple onchange="handleSelectChange(event); filterTable()"></select>
 
-  <label for="filterType">Produkt:</label>
-  <select id="filterType" multiple onchange="filterTable()"></select>
+    <label for="filterYear">Förfalloår:</label>
+    <select id="filterYear" multiple onchange="handleSelectChange(event); filterTable()"></select>
 
-  <label for="filterYear">Förfalloår:</label>
-  <select id="filterYear" multiple onchange="filterTable()"></select>
+    <label for="filterDuration">Löptid (mån):</label>
+    <select id="filterDuration" multiple onchange="handleSelectChange(event); filterTable()"></select>
 
-  <label for="filterDuration">Löptid (mån):</label>
-  <select id="filterDuration" multiple onchange="filterTable()"></select>
+    <label for="filterLocation">Plats:</label>
+    <select id="filterLocation" multiple onchange="handleSelectChange(event); filterTable()"></select>
 
-  <label for="filterLocation">Plats:</label>
-  <select id="filterLocation" multiple onchange="filterTable()"></select>
-
-  <label for="filterStatus">Tillgångsstatus:</label>
-  <select id="filterStatus" multiple onchange="filterTable()"></select>
+    <label for="filterStatus">Tillgångsstatus:</label>
+    <select id="filterStatus" multiple onchange="handleSelectChange(event); filterTable()"></select>
+  </div>
 
   <table id="contractTable">
     <thead>
@@ -117,6 +131,22 @@ const searchSerial = document.getElementById("searchSerial");
 const searchContract = document.getElementById("searchContract");
 const summaryDiv = document.getElementById("summary");
 
+function addAllOption(selectEl) {
+  selectEl.add(new Option("Alla", "all"));
+}
+
+function handleSelectChange(event) {
+  const selectEl = event.target;
+  const allOption = selectEl.options[0];
+  const otherOptions = Array.from(selectEl.options).slice(1);
+
+  if (allOption.selected) {
+    otherOptions.forEach(opt => opt.selected = true);
+  }
+
+  allOption.selected = otherOptions.every(opt => opt.selected);
+}
+
 function loadExcel(event) {
   const file = event.target.files[0];
   const reader = new FileReader();
@@ -148,6 +178,8 @@ function initFilters() {
   filterLocation.innerHTML = "";
   filterStatus.innerHTML = "";
 
+  [filterType, filterYear, filterDuration, filterLocation, filterStatus].forEach(addAllOption);
+
   const types = new Set();
   const years = new Set();
   const durations = new Set();
@@ -165,10 +197,15 @@ function initFilters() {
   [...durations].sort((a, b) => a - b).forEach(d => filterDuration.add(new Option(d, d)));
   [...locations].sort().forEach(loc => filterLocation.add(new Option(loc, loc)));
   [...statuses].sort().forEach(s => filterStatus.add(new Option(s, s)));
+
+  [filterType, filterYear, filterDuration, filterLocation, filterStatus].forEach(select => {
+    Array.from(select.options).forEach(opt => opt.selected = true);
+  });
 }
 
 function getSelectedValues(selectEl) {
-  return Array.from(selectEl.selectedOptions).map(option => option.value);
+  const values = Array.from(selectEl.selectedOptions).map(option => option.value);
+  return values.includes("all") ? [] : values.filter(v => v !== "all");
 }
 
   function filterTable() {


### PR DESCRIPTION
## Summary
- moderniserad layout med flex-wrap och card-liknande filtersektion
- alla filterfält får "Alla"-val som markerar samtliga alternativ
- filterhantering uppdaterad för att stödja "select all"

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_684973fc174c8328a98fb9647cfbeba7